### PR TITLE
fix: handle tiny scientific notation

### DIFF
--- a/src/NumberDecimal.ts
+++ b/src/NumberDecimal.ts
@@ -1,5 +1,5 @@
 import type { DecimalClass, ValueType } from './interface';
-import { getNumberPrecision, isEmpty, num2str } from './numberUtil';
+import { getNumberPrecision, isE, isEmpty, num2str } from './numberUtil';
 
 /**
  * We can remove this when IE not support anymore
@@ -108,6 +108,10 @@ export default class NumberDecimal implements DecimalClass {
 
     if (this.isInvalidate()) {
       return '';
+    }
+
+    if (isE(this.number) && getNumberPrecision(this.number) > 100) {
+      return String(this.number);
     }
 
     return num2str(this.number);

--- a/src/numberUtil.ts
+++ b/src/numberUtil.ts
@@ -59,6 +59,28 @@ export function isE(number: string | number) {
   return !Number.isNaN(Number(str)) && str.includes('e');
 }
 
+function expandScientificNotation(numStr: string) {
+  const [mantissa, exponent] = numStr.toLowerCase().split('e');
+  const exp = Number(exponent);
+  const negative = mantissa.startsWith('-');
+  const unsignedMantissa = negative ? mantissa.slice(1) : mantissa;
+  const [integer = '0', decimal = ''] = unsignedMantissa.split('.');
+  const digits = `${integer}${decimal}`.replace(/^0+/, '') || '0';
+  const decimalIndex = integer.length + exp;
+
+  let expanded = '';
+
+  if (decimalIndex <= 0) {
+    expanded = `0.${'0'.repeat(-decimalIndex)}${digits}`;
+  } else if (decimalIndex >= digits.length) {
+    expanded = `${digits}${'0'.repeat(decimalIndex - digits.length)}`;
+  } else {
+    expanded = `${digits.slice(0, decimalIndex)}.${digits.slice(decimalIndex)}`;
+  }
+
+  return `${negative ? '-' : ''}${expanded}`;
+}
+
 /**
  * [Legacy] Convert 1e-9 to 0.000000001.
  * This may lose some precision if user really want 1e-9.
@@ -99,7 +121,12 @@ export function num2str(number: number): string {
       );
     }
 
-    numStr = number.toFixed(getNumberPrecision(numStr));
+    const precision = getNumberPrecision(numStr);
+
+    numStr =
+      precision > 100
+        ? expandScientificNotation(numStr)
+        : number.toFixed(precision);
   }
 
   return trimNumber(numStr).fullStr;

--- a/tests/util.test.tsx
+++ b/tests/util.test.tsx
@@ -38,6 +38,8 @@ describe('InputNumber.Util', () => {
 
   classList.forEach(({ name, getDecimal, mockSupportBigInt }) => {
     describe(name, () => {
+      const tinyScientificValue = `0.${'0'.repeat(306)}1`;
+
       beforeEach(() => {
         supportBigInt.mockImplementation(() => {
           return mockSupportBigInt !== false;
@@ -59,6 +61,12 @@ describe('InputNumber.Util', () => {
         expect(getDecimal('-0').toString()).toEqual('0');
         expect(getDecimal('.1').toString()).toEqual('0.1');
         expect(getDecimal('1.').toString()).toEqual('1');
+      });
+
+      it('parses very small scientific notation', () => {
+        expect(getDecimal('1e-307').toString()).toEqual(
+          mockSupportBigInt === false ? '1e-307' : tinyScientificValue,
+        );
       });
 
       it('invalidate', () => {


### PR DESCRIPTION
## Summary
- avoid throwing when parsing very small scientific notation such as 1e-307
- keep NumberDecimal output in scientific notation for extreme tiny values
- add coverage for default, BigIntDecimal, and NumberDecimal parsing expectations

## Testing
- not run (local test runner unavailable: umi-test not installed in this environment)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **新功能**
  * 优化了数值显示逻辑，改进了科学计数法形式数字（特别是极小数值）的格式化处理，增强了高精度数值的支持。

* **测试**
  * 添加新的测试用例，覆盖超小科学计数法数值的解析与显示验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->