### PR TITLE
fix: avoid parse errors in older umi builds

### DIFF
--- a/src/BigIntDecimal.ts
+++ b/src/BigIntDecimal.ts
@@ -7,17 +7,10 @@ import {
   validateNumber,
 } from './numberUtil';
 
-export default class BigIntDecimal implements DecimalClass {
-  origin: string = '';
-  negative: boolean;
-  integer: bigint;
-  decimal: bigint;
-  /** BigInt will convert `0009` to `9`. We need record the len of decimal */
-  decimalLen: number;
-  empty: boolean;
-  nan: boolean;
-
+class BigIntDecimal implements DecimalClass {
   constructor(value: string | number) {
+    this.origin = '';
+
     if (isEmpty(value)) {
       this.empty = true;
       return;
@@ -164,7 +157,7 @@ export default class BigIntDecimal implements DecimalClass {
   }
 
   equals(target: DecimalClass) {
-    return this.toString() === target?.toString();
+    return this.toString() === (target ? target.toString() : undefined);
   }
 
   lessEquals(target: DecimalClass) {
@@ -192,3 +185,16 @@ export default class BigIntDecimal implements DecimalClass {
     ).fullStr;
   }
 }
+
+interface BigIntDecimal {
+  origin: string;
+  negative: boolean;
+  integer: bigint;
+  decimal: bigint;
+  /** BigInt will convert `0009` to `9`. We need record the len of decimal */
+  decimalLen: number;
+  empty: boolean;
+  nan: boolean;
+}
+
+export default BigIntDecimal;

--- a/src/NumberDecimal.ts
+++ b/src/NumberDecimal.ts
@@ -4,12 +4,10 @@ import { getNumberPrecision, isE, isEmpty, num2str } from './numberUtil';
 /**
  * We can remove this when IE not support anymore
  */
-export default class NumberDecimal implements DecimalClass {
-  origin: string = '';
-  number: number;
-  empty: boolean;
-
+class NumberDecimal implements DecimalClass {
   constructor(value: ValueType) {
+    this.origin = '';
+
     if (isEmpty(value)) {
       this.empty = true;
       return;
@@ -90,7 +88,7 @@ export default class NumberDecimal implements DecimalClass {
   }
 
   equals(target: DecimalClass) {
-    return this.toNumber() === target?.toNumber();
+    return this.toNumber() === (target ? target.toNumber() : undefined);
   }
 
   lessEquals(target: DecimalClass) {
@@ -117,3 +115,11 @@ export default class NumberDecimal implements DecimalClass {
     return num2str(this.number);
   }
 }
+
+interface NumberDecimal {
+  origin: string;
+  number: number;
+  empty: boolean;
+}
+
+export default NumberDecimal;


### PR DESCRIPTION
## Summary
- remove class field syntax from `NumberDecimal` and `BigIntDecimal` source so the published build output no longer contains `origin = ''` style class fields
- replace optional chaining in equality checks with plain guards to avoid shipping additional modern syntax in the package output
- keep runtime behavior unchanged while restoring compatibility for older Umi 3.x build pipelines

## Testing
- ut run lint:tsc
- ut run compile
- ut run test

Fixes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **重构**
  * 优化了内部API结构，将类实现转换为公共接口，提高了类型安全性。

* **Bug修复**
  * 改进了相等性比较逻辑，更准确地处理边界情况。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->