### PR TITLE
fix: adjust father targets from chrome 85 to ie11

### DIFF
--- a/.fatherrc.js
+++ b/.fatherrc.js
@@ -2,4 +2,7 @@ import { defineConfig } from 'father';
 
 export default defineConfig({
   plugins: ['@rc-component/father-plugin'],
+  targets: {
+    ie: 11,
+  },
 });


### PR DESCRIPTION
solve issue: https://github.com/react-component/mini-decimal/issues/5

Because rc father-plugin set target to: chorme 85(which allows `class` and not downgrade the syntax):

https://github.com/react-component/father-plugin/blob/main/src/index.ts#L70

In this repo just change the target to `ie11` to make `class` syntax downgrade:

<img width="2582" height="1272" alt="image" src="https://github.com/user-attachments/assets/294041e2-10e9-429a-96fe-6952a9398c11" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 添加了对 Internet Explorer 11 浏览器的支持。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->